### PR TITLE
underscore, not downcase resource name

### DIFF
--- a/lib/sync/resource.rb
+++ b/lib/sync/resource.rb
@@ -11,7 +11,7 @@ module Sync
     end
 
     def name
-      model.class.model_name.to_s.downcase
+      model.class.model_name.to_s.underscore
     end
 
     def plural_name


### PR DESCRIPTION
multi-word resource names (and subsequent partial directories) should be separated with underscores to preserve rails naming conventions, ie "video_replies", not "videoreplies"
