### PR TITLE
Have view helpers return strings.

### DIFF
--- a/lib/sync/view_helpers.rb
+++ b/lib/sync/view_helpers.rb
@@ -6,9 +6,10 @@ module Sync
       partial_name = options.fetch(:partial, channel)
       collection   = options[:collection] || [options.fetch(:resource)]
       
+      result = [] 
       collection.each do |resource|
         partial = Sync::Partial.new(partial_name, resource, channel, self)
-        concat "
+        result << "
           <script type='text/javascript' data-sync-id='#{partial.selector_start}'>
             Sync.onReady(function(){
               var partial = new Sync.Partial(
@@ -22,14 +23,14 @@ module Sync
             });
           </script>
         ".html_safe
-        concat(partial.render)
-        concat "
+        result << partial.render
+        result << "
           <script type='text/javascript' data-sync-id='#{partial.selector_end}'>
           </script>
         ".html_safe
       end
 
-      nil
+      safe_join(result)
     end
 
     def sync_new(options = {})
@@ -37,7 +38,7 @@ module Sync
       resource     = options.fetch(:resource)
       scope        = options[:scope]
       creator = Sync::PartialCreator.new(partial_name, resource, scope, self)
-      concat "
+      "
         <script type='text/javascript' data-sync-id='#{creator.selector}'>
           Sync.onReady(function(){
             var creator = new Sync.PartialCreator(
@@ -49,8 +50,6 @@ module Sync
           });
         </script>
       ".html_safe
-
-      nil
     end
   end
 end


### PR DESCRIPTION
That way, their results will be embedded exactly where they are
used in templates, regardless of the rendering engine.

This solved #3 for me.

Feel free to ignore this, if the use of concat had some reasons that were not clear to me. From what I gather from the documentation of the concat method, its use is rather discouraged.
