### PR TITLE
Fixed partial 'Unrecognized Expression' bug with trim

### DIFF
--- a/app/assets/javascripts/sync.coffee.erb
+++ b/app/assets/javascripts/sync.coffee.erb
@@ -99,7 +99,7 @@ class Sync.View
   show: -> @$el.show()
 
   update: (html) -> 
-    $new = $(html)
+    $new = $($.trim(html))
     @$el.replaceWith($new)
     @$el = $new
     @afterUpdate()


### PR DESCRIPTION
This trims the response from the synchronized partial before sending it to $() and inserting it into the element.
