### PR TITLE
Direction of partial inserts

### DIFF
--- a/app/assets/javascripts/sync.coffee.erb
+++ b/app/assets/javascripts/sync.coffee.erb
@@ -160,7 +160,7 @@ class Sync.PartialCreator
 
 
   insert: (html, channelUpdate, channelDestroy, selectorStart, selectorEnd) ->
-    @$el.before """
+    @$el.after """
       <script type='text/javascript' data-sync-id='#{selectorStart}'></script>
       <script type='text/javascript' data-sync-el-placeholder></script>
       <script type='text/javascript' data-sync-id='#{selectorEnd}'></script>


### PR DESCRIPTION
Didn't have time to make this into a configurable option, but wanted to point out that sometimes it's useful to insert new partials at the top, for instance for a live stream of tweets or something.
