### PR TITLE
Always load sync.config initializer if Rails loaded; Fixes #30

### DIFF
--- a/lib/sync/engine.rb
+++ b/lib/sync/engine.rb
@@ -2,7 +2,7 @@ module Sync
 
   class Engine < Rails::Engine
     # Loads the sync.yml file if it exists.
-    initializer "sync.config" do
+    initializer "sync.config", group: :all do
       path = Rails.root.join("config/sync.yml")
       Sync.load_config(path, Rails.env) if path.exist?
     end


### PR DESCRIPTION
I'm not 100% sure what this does. But I got it from this (now down) [posterous post](http://webcache.googleusercontent.com/search?q=cache:MMdPCUxEjzgJ:timcardenas.com/how-to-develop-engines-that-compile-assets-on+&cd=1&hl=en&ct=clnk&gl=us)

I'm guessing it forces loading the initializer when rails is loaded. Seems to fix the problem.

Fixes #30.
