### PR TITLE
WIP: Support for multi_fetch_fragments

### DIFF
--- a/lib/sync.rb
+++ b/lib/sync.rb
@@ -5,6 +5,7 @@ require "net/https"
 require 'sync/renderer'
 require 'sync/actions'
 require 'sync/controller_helpers'
+require 'sync/partial_cache'
 require 'sync/view_helpers'
 require 'sync/model'
 require 'sync/faye_extension'

--- a/lib/sync/partial.rb
+++ b/lib/sync/partial.rb
@@ -27,13 +27,21 @@ module Sync
       context.render(partial: path, locals: locals, formats: [:html])
     end
 
-    def cache_key(key)
-      key
+    def cache_key(transform = nil)
+      key = transform ? transform.call(resource.model) : resource.model
+
+      # if defined?(template.fragment_name_with_digest)
+      #   key = template.fragment_name_with_digest(key, template.view_cache_dependencies)
+      # elsif defined?(template.cache_fragment_name)
+      #   key = template.cache_fragment_name(key)
+      # end
+
+      context.controller.fragment_cache_key(key)
     end
 
-    def template
-      @template ||= context.find_template(path)
-    end
+    # def template
+    #   @template ||= context.find_template(path)
+    # end
 
     def sync(action)
       message(action).publish

--- a/lib/sync/partial.rb
+++ b/lib/sync/partial.rb
@@ -27,6 +27,14 @@ module Sync
       context.render(partial: path, locals: locals, formats: [:html])
     end
 
+    def cache_key(key)
+      key
+    end
+
+    def template
+      @template ||= context.find_template(path)
+    end
+
     def sync(action)
       message(action).publish
     end

--- a/lib/sync/partial_cache.rb
+++ b/lib/sync/partial_cache.rb
@@ -1,0 +1,60 @@
+module Sync
+  class PartialCache
+    def self.for(cache)
+      if cache.respond_to? :call
+        new(TransformKeyGenerator.new(cache), Rails.cache)
+      elsif cache
+        new(KeyGenerator.new, Rails.cache)
+      else
+        NoCache.new
+      end
+    end
+
+    attr_reader :key_generator, :store
+
+    def initialize(key_generator, store)
+      @key_generator = key_generator
+      @store = store
+    end
+
+    def key_for(partial)
+      key_generator.key_for(partial)
+    end
+
+    def fetch(partials, &block)
+      keys = partials.map { |partial| key_for(partial) }
+      result = store.read_multi(*keys)
+
+      partials.each_with_index.map do |partial, index|
+        key = keys[index]
+        result.fetch(key) do
+          block.call(partial).tap { |result| store.write(key, result) }
+        end
+      end
+    end
+
+    class KeyGenerator
+      def key_for(partial)
+        partial.cache_key
+      end
+    end
+
+    class TransformKeyGenerator
+      attr_reader :transform
+
+      def initialize(transform)
+        @transform = transform
+      end
+
+      def key_for(partial)
+        partial.cache_key(transform)
+      end
+    end
+
+    class NoCache
+      def fetch(partials)
+        partials.map { |partial| yield partial }
+      end
+    end
+  end
+end

--- a/lib/sync/view_helpers.rb
+++ b/lib/sync/view_helpers.rb
@@ -2,13 +2,13 @@ module Sync
 
   module ViewHelpers
 
-    # Surround partial render in script tags, watching for 
+    # Surround partial render in script tags, watching for
     # sync_update and sync_destroy channels from pubsub server
     #
     # options - The Hash of options
     #   partial - The String partial filename without leading underscore
     #   resource - The ActiveModel resource
-    #   collection - The Array of ActiveModel resources to use in place of 
+    #   collection - The Array of ActiveModel resources to use in place of
     #                single resource
     #
     # Examples
@@ -19,10 +19,14 @@ module Sync
       channel      = options[:channel]
       partial_name = options.fetch(:partial, channel)
       collection   = options[:collection] || [options.fetch(:resource)]
-      
-      result = [] 
-      collection.each do |resource|
-        partial = Sync::Partial.new(partial_name, resource, channel, self)
+      cache        = PartialCache.for(options[:cache])
+
+      partials = collection.map { |resource|
+        Sync::Partial.new(partial_name, resource, channel, self)
+      }
+
+      all_results = cache.fetch(partials) do |partial|
+        result = []
         result << "
           <script type='text/javascript' data-sync-id='#{partial.selector_start}'>
             Sync.onReady(function(){
@@ -45,7 +49,7 @@ module Sync
         ".html_safe
       end
 
-      safe_join(result)
+      safe_join(all_results.flatten)
     end
 
     # Setup listener for new resource from sync_new channel, appending
@@ -56,16 +60,16 @@ module Sync
     #   resource - The ActiveModel resource
     #   scope - The ActiveModel resource to scope the new channel publishes to.
     #           Used for restricting new resource publishes to 'owner' models.
-    #           ie, current_user, project, group, etc. When excluded, listens 
+    #           ie, current_user, project, group, etc. When excluded, listens
     #           for global resource creates.
-    # 
+    #
     #   direction - The String/Symbol direction to insert rendered partials.
     #               One of :append, :prepend. Defaults to :append
     #
     # Examples
     #   <%= sync_new partial: 'todo', resource: Todo.new, scope: @project %>
     #   <%= sync_new partial: 'todo', resource: Todo.new, scope: @project, direction: :prepend %>
-    #  
+    #
     def sync_new(options = {})
       partial_name = options.fetch(:partial)
       resource     = options.fetch(:resource)

--- a/test/sync/partial_cache_test.rb
+++ b/test/sync/partial_cache_test.rb
@@ -1,0 +1,67 @@
+require_relative '../test_helper'
+require 'mocha/setup'
+require 'active_support'
+
+describe Sync::PartialCache do
+  describe "when cache is disabled" do
+    it "does not cache" do
+       cache = Sync::PartialCache.for(false)
+       results = cache.fetch([1, 2]) do |partial|
+         partial + 1
+       end
+
+       assert_equal [2, 3], results
+
+       results = cache.fetch([1, 2]) do |partial|
+         partial + 2
+       end
+
+       assert_equal [3, 4], results
+    end
+  end
+
+  describe "when cache is enabled" do
+    before do
+      Rails.stubs(:cache).returns(ActiveSupport::Cache::MemoryStore.new)
+    end
+
+    it "does cache" do
+      cached_partial = stub(cache_key: 'cached')
+      uncached_partial = stub(cache_key: 'uncached')
+      cache = Sync::PartialCache.for(true)
+
+      Rails.cache.write('cached', 'cached result')
+
+      results = cache.fetch([cached_partial, uncached_partial]) do |partial|
+        'uncached result'
+      end
+
+      assert_equal ['cached result', 'uncached result'], results
+
+      results = cache.fetch([cached_partial, uncached_partial]) do |partial|
+        raise "#{partial} should be cached"
+      end
+
+      assert_equal ['cached result', 'uncached result'], results
+    end
+
+    it "transforms keys if passed a transform" do
+      transform = lambda { |x| }
+      partial = stub
+      partial.stubs(:cache_key).with(transform).returns("transformed")
+
+      cache = Sync::PartialCache.for(transform)
+
+      assert_equal "transformed", cache.key_for(partial)
+    end
+
+    it "does not transforms keys if not passed a transform" do
+      partial = stub
+      partial.stubs(:cache_key).with().returns("not transformed")
+
+      cache = Sync::PartialCache.for(true)
+
+      assert_equal "not transformed", cache.key_for(partial)
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,6 +10,8 @@ require_relative 'em_minitest_spec'
 
 Bundler.require(:default)
 
+module Rails; end
+
 def setup_database
   ActiveRecord::Base.send :extend, Sync::Model::ClassMethods
   ActiveRecord::Base.establish_connection(


### PR DESCRIPTION
Here's another wish-list item... it'd be great if sync either integrated with or natively did what https://github.com/n8/multi_fetch_fragments/ did. It would be good if the fragment cached actually included the script tags. So you could do something like this:

```haml
  = sync partial: 'list_item', collection: things, scope: scope, cache: true
```

and each cache fragment would include the script tags as well as the view.