### PR TITLE
Use with cache_digests

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,37 @@ class Sync.TodoListRow extends Sync.View
 
 ```
 
+## Using with cache_digests (Russian doll caching)
+
+Sync has a custom `DependencyTracker::ERBTracker` that can handle `sync` render calls.
+Because the full partial name is not included, it has to guess the location of
+your partial based on the name of the `resource` or `collection` passed to it.
+See the tests to see how it works. If it doesn't work for you, you can always
+use the [explicit "Template Dependency"
+markers](https://github.com/rails/cache_digests).
+
+To enable, add to `config/initializers/cache_digests.rb`:
+
+#### Rails 4
+
+```ruby
+require 'action_view/dependency_tracker'
+
+ActionView::DependencyTracker.register_tracker :haml, Sync::ERBTracker
+ActionView::DependencyTracker.register_tracker :erb, Sync::ERBTracker
+```
+
+#### Rails 3 with [cache_digests](https://github.com/rails/cache_digests) gem
+
+```ruby
+require 'cache_digests/dependency_tracker'
+
+CacheDigests::DependencyTracker.register_tracker :haml, Sync::ERBTracker
+CacheDigests::DependencyTracker.register_tracker :erb, Sync::ERBTracker
+```
+
+**Note:** haml support is limited, but it seems to work in most cases.
+
 ## Brief Example or [checkout an example application](https://github.com/chrismccord/sync_example)
 
 View `sync/users/_user_list_row.html.erb`

--- a/lib/sync.rb
+++ b/lib/sync.rb
@@ -16,7 +16,10 @@ require 'sync/resource'
 require 'sync/clients/faye'
 require 'sync/clients/pusher'
 require 'sync/reactor'
-require 'sync/engine' if defined? Rails
+if defined? Rails
+  require 'sync/erb_tracker'
+  require 'sync/engine'
+end
 
 module Sync
 

--- a/lib/sync/erb_tracker.rb
+++ b/lib/sync/erb_tracker.rb
@@ -1,0 +1,49 @@
+module Sync
+  tracker_class = nil
+  begin
+    require 'action_view/dependency_tracker'
+    tracker_class = ActionView::DependencyTracker::ERBTracker
+  rescue LoadError
+    begin
+      require 'cache_digests/dependency_tracker'
+      tracker_class = CacheDigests::DependencyTracker::ERBTracker
+    rescue LoadError
+    end
+  end
+
+  if tracker_class
+    class ERBTracker < tracker_class
+      # Matches:
+      #   sync partial: "comment", collection: commentable.comments
+      #   sync partial: "comment", resource: comment
+      SYNC_DEPENDENCY = /
+        sync(?:_new)?\s*                         # sync or sync_new, followed by optional whitespace
+        \(?\s*                                   # start an optional parenthesis for the sync call
+        (?:partial:|:partial\s+=>)\s*            # naming the partial, used with collection
+        ["']([a-z][a-z_\/]+)["']\s*              # the template name itself -- 1st capture
+        ,\s*                                     # comma separating parameters
+        :?(?:resource|collection)(?::|\s+=>)\s*  # resource or collection identifier
+        @?(?:[a-z]+\.)*([a-z]+)                  # the resource or collection itself -- 2nd capture
+      /x
+
+      def self.call(name, template)
+        new(name, template).dependencies
+      end
+
+      def dependencies
+        (sync_dependencies + super).uniq
+      end
+
+      private
+
+      def source
+        template.source
+      end
+
+      def sync_dependencies
+        source.scan(SYNC_DEPENDENCY).
+          collect { |template, resource| "sync/#{resource.pluralize}/#{template}" }
+      end
+    end
+  end
+end

--- a/sync.gemspec
+++ b/sync.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pusher', '~> 0.11.3'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rails', '~> 3.2.13'
+  s.add_development_dependency 'cache_digests'
   s.add_development_dependency 'mocha', '~> 0.13.3'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'pry'

--- a/test/sync/erb_tracker_test.rb
+++ b/test/sync/erb_tracker_test.rb
@@ -1,0 +1,72 @@
+require_relative '../test_helper'
+require 'rails/all'
+require 'active_support/core_ext/array/access'
+require 'sync/erb_tracker'
+
+describe Sync::ERBTracker do
+  Template = Struct.new(:source)
+  it 'tracks collection partials' do
+    dependencies = Sync::ERBTracker.call "name", Template.new(<<-TEMPLATE)
+      <%= sync partial: 'item', collection: something.things %>
+    TEMPLATE
+
+    assert_equal ['sync/things/item'], dependencies
+  end
+
+  it 'tracks collection instance variable partials' do
+    dependencies = Sync::ERBTracker.call "name", Template.new(<<-TEMPLATE)
+      <%= sync partial: 'item', collection: @something.things %>
+    TEMPLATE
+
+    assert_equal ['sync/things/item'], dependencies
+  end
+
+  it 'tracks resource partials' do
+    dependencies = Sync::ERBTracker.call "name", Template.new(<<-TEMPLATE)
+      <%= sync partial: 'item', resource: thing %>
+    TEMPLATE
+
+    assert_equal ['sync/things/item'], dependencies
+  end
+
+  it 'tracks sync_new partials' do
+    dependencies = Sync::ERBTracker.call "name", Template.new(<<-TEMPLATE)
+      <%= sync_new partial: 'item', resource: thing %>
+    TEMPLATE
+
+    assert_equal ['sync/things/item'], dependencies
+  end
+
+  it 'tracks multiple sync partials' do
+    dependencies = Sync::ERBTracker.call "name", Template.new(<<-TEMPLATE)
+      <%= sync partial: 'item', resource: thing %>
+      <%= sync partial: 'other_item', resource: rock %>
+    TEMPLATE
+
+    assert_equal ['sync/things/item', 'sync/rocks/other_item'], dependencies
+  end
+
+  it 'tracks resource instance variable partials' do
+    dependencies = Sync::ERBTracker.call "name", Template.new(<<-TEMPLATE)
+      <%= sync partial: 'item', resource: @thing %>
+    TEMPLATE
+
+    assert_equal ['sync/things/item'], dependencies
+  end
+
+  it 'tracks haml resource partials' do
+    dependencies = Sync::ERBTracker.call "name", Template.new(<<-TEMPLATE)
+      =sync partial: 'item', resource: thing
+    TEMPLATE
+
+    assert_equal ['sync/things/item'], dependencies
+  end
+
+  it 'tracks regular renders too' do
+    dependencies = Sync::ERBTracker.call "name", Template.new(<<-TEMPLATE)
+      <%= render partial: 'things/item', collection: things %>
+    TEMPLATE
+
+    assert_equal ['things/item'], dependencies
+  end
+end


### PR DESCRIPTION
I may turn this into a pull request in a few, but on my project I used this to get cache digests paying attention to `sync` calls:

In `lib/sync_tracker.rb`:

``` ruby
require 'action_view/dependency_tracker'

class SyncTracker < ActionView::DependencyTracker::ERBTracker
  # Matches:
  #   sync partial: "comment", collection: commentable.comments
  #   sync partial: "comment", resource: comment
  SYNC_DEPENDENCY = /
    sync\s*                                   # sync, followed by optional whitespace
    \(?\s*                                    # start an optional parenthesis for the sync call
    (?:partial:|:partial\s+=>)\s*             # naming the partial, used with collection
    ["']([a-z][a-z_\/]+)["']\s*               # the template name itself -- 1st capture
    ,\s*                                      # comma separating parameters
    :?(?:resource|collection)(?::|\s+=>)\s*   # resource or collection identifier
    @?(?:[a-z]+\.)*([a-z]+)                   # the resource or collection itself -- 2nd capture
  /x

  def self.call(name, template)
    new(name, template).dependencies
  end

  def dependencies
    (sync_dependencies + super).uniq
  end

  private

  def source
    template.source
  end

  def sync_dependencies
    source.scan(SYNC_DEPENDENCY).
      collect { |template, resource| "sync/#{resource.pluralize}/#{template}" }
  end
end
```

In `config/initializers/cache_digests.rb`:

``` ruby
require 'action_view/dependency_tracker'
ActionView::DependencyTracker.register_tracker :haml, SyncTracker
ActionView::DependencyTracker.register_tracker :erb, SyncTracker
```
