### PR TITLE
Fix namespaced locals

### DIFF
--- a/lib/sync/partial.rb
+++ b/lib/sync/partial.rb
@@ -71,7 +71,7 @@ module Sync
 
     def locals
       locals_hash = {}
-      locals_hash[resource.name.to_sym] = resource.model
+      locals_hash[resource.name.split('/').last.to_sym] = resource.model
 
       locals_hash
     end

--- a/lib/sync/resource.rb
+++ b/lib/sync/resource.rb
@@ -57,7 +57,7 @@ module Sync
     end
 
     def name
-      model.class.model_name.to_s.underscore.split('/').last
+      model.class.model_name.to_s.underscore
     end
 
     def plural_name

--- a/lib/sync/resource.rb
+++ b/lib/sync/resource.rb
@@ -57,7 +57,7 @@ module Sync
     end
 
     def name
-      model.class.model_name.to_s.underscore.model.split('/').last
+      model.class.model_name.to_s.underscore.split('/').last
     end
 
     def plural_name

--- a/lib/sync/resource.rb
+++ b/lib/sync/resource.rb
@@ -57,7 +57,7 @@ module Sync
     end
 
     def name
-      model.class.model_name.to_s.underscore
+      model.class.model_name.to_s.underscore.model.split('/').last
     end
 
     def plural_name


### PR DESCRIPTION
If locals has a namespace, name of resource return something like "spree/parser/conflict" and then it convert to sym :"spree/parser/conflict", so in `partial.rb` in `render` method locals will be like this `#=> :"spree/parser/conflict"` so render method read it uncorrectily and cause errors like `undefined local variable or method`parser' for #<#Class:0x007f87e55154e0:0x007f87e34b7ab8>`. This pull request take only class name from model_name and there is no errors for now.
