### PR TITLE
Make scopes more flexible.

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,16 +224,33 @@ class Sync.TodoListRow extends Sync.View
 
 ## Narrowing sync_new scope
 
+Sometimes, you do not want your page to update with every new record. With the `scope` option, you can limit what is being updated on a given page.
+
+One way of using `scope` is by supplying a String or a Symbol. This is useful for example when you want to only show new records for a given locale:
+
 View:
 ```erb
-<%= sync_new partial: 'todo_list_row', resource: Todo.new, scope: [@project, :staff] %>
+<%= sync_new partial: 'todo_list_row', resource: Todo.new, scope: I18n.locale %>
 ```
 
 Controller/Model:
 ```ruby
-sync_new @todo, scope: [@project, :staff]
+sync_new @todo, scope: @todo.locale
 ```
 
+Another use of `scope` is with a parent resource. This way you can for example update a project page with new todos for this single project:
+
+View:
+```erb
+<%= sync_new partial: 'todo_list_row', resource: Todo.new, scope: @project %>
+```
+
+Controller/Model:
+```ruby
+sync_new @todo, scope: @project
+```
+
+Both approaches can be combined. Just supply an Array of Strings/Symbols and/or parent resources to the `scope` option. Note that the order of elements matters. Be sure to use the same order in your view and in your controller/model.
 
 ## Refetching Partials
 

--- a/lib/sync/partial_creator.rb
+++ b/lib/sync/partial_creator.rb
@@ -2,14 +2,10 @@ module Sync
   class PartialCreator
     attr_accessor :name, :resource, :context, :partial
 
-    def initialize(name, resource, scoped_resource, context)
+    def initialize(name, resource, scopes, context)
       self.name = name
-      self.resource = Resource.new(resource)
+      self.resource = Resource.new(resource, scopes)
       self.context = context
-      if scoped_resource
-        scopes = [scoped_resource].flatten
-        self.resource.parent = Resource.new(scopes.first, scopes[1..-1])
-      end
       self.partial = Partial.new(name, self.resource.model, nil, context)
     end
 

--- a/test/sync/resource_test.rb
+++ b/test/sync/resource_test.rb
@@ -11,13 +11,13 @@ describe Sync::Partial do
     @user = User.new
     @project = Project.new
   end
- 
+
   describe '#name' do
     it 'returns the underscored model class name' do
       assert_equal "user", Sync::Resource.new(@user).name
     end
   end
-  
+
   describe '#plural_name' do
     it 'returns the underscored model class name' do
       assert_equal "users", Sync::Resource.new(@user).plural_name
@@ -30,70 +30,108 @@ describe Sync::Partial do
     end
   end
 
-  describe '#channel' do
-    it 'returns nil when no channel is given' do
-      refute Sync::Resource.new(@user).channel
+  describe '#scopes=' do
+    before do
+      @resource = Sync::Resource.new(@user)
     end
 
-    it 'sets the channel to the passed string' do
-      assert_equal "admin", Sync::Resource.new(@user, "admin").channel
+    it 'ignores nil' do
+      @resource.scopes = nil
+      assert_nil @resource.scopes
     end
 
-    it 'sets the channel as the joined array of symbols' do
-      assert_equal "admin/restricted", Sync::Resource.new(@user, [:admin, :restricted]).channel
+    it 'converts scalar value to an array' do
+      @resource.scopes = :en
+      assert_equal [:en], @resource.scopes
     end
 
-    it 'sets the channel as the joined array of strings' do
-      assert_equal "admin/restricted", Sync::Resource.new(@user, ["admin", "restricted"]).channel
-    end
   end
 
-  describe 'parent' do
-    it 'defaults to NullResource if no parent is given' do
-      assert_equal Sync::NullResource, Sync::Resource.new(@user).parent.class
+  describe '#scopes_path' do
+    describe 'a resource without a scope' do
+      it 'returns /' do
+        resource = Sync::Resource.new(@user)
+        assert_equal '/', resource.scopes_path.to_s
+      end
     end
 
-    it 'sets the parent to given resource' do
-      resource = Sync::Resource.new(@user)
-      parent = Sync::Resource.new(@user)
-      resource.parent = parent
-      assert_equal parent, resource.parent
+    describe 'a resource with a simple scope' do
+      it 'returns a path prefixed with the scope' do
+        resource = Sync::Resource.new(@user, :admin)
+        assert_equal '/admin', resource.scopes_path.to_s
+      end
+    end
+
+    describe 'a resource with a parent model as scope' do
+      it "returns the parent model's path" do
+        resource = Sync::Resource.new(@user, @project)
+        assert_equal '/projects/1', resource.scopes_path.to_s
+      end
+    end
+
+    describe 'a resource with mixed scopes' do
+      it 'returns a path including all scopes' do
+        resource = Sync::Resource.new(@user, [:en, :admin, @project])
+        assert_equal '/en/admin/projects/1', resource.scopes_path.to_s
+      end
     end
   end
 
   describe '#polymorphic_path' do
-    it 'returns the path for the model' do
-      assert_equal "/users/1", Sync::Resource.new(@user).polymorphic_path.to_s
+    describe 'a resource without a scope' do
+      it 'returns the path for the model' do
+        assert_equal "/users/1", Sync::Resource.new(@user).polymorphic_path.to_s
+      end
     end
 
-    it 'returns the path for the model, prefixed by parent path' do
-      child = Sync::Resource.new(@user)
-      child.parent = Sync::Resource.new(@project)
-      assert_equal "/projects/1/users/1", child.polymorphic_path.to_s
+    describe 'a resource with a simple scope' do
+      it 'returns the path for the model, prefixed by the scope' do
+        resource = Sync::Resource.new(@user, :en) 
+        assert_equal "/en/users/1", resource.polymorphic_path.to_s
+      end
     end
 
-    it 'returns the path for the model, prefixed by parent path and channel' do
-      child = Sync::Resource.new(@user)
-      child.parent = Sync::Resource.new(@project, :admin)
-      assert_equal "/admin/projects/1/users/1", child.polymorphic_path.to_s
+    describe 'a resource with a parent model as scope' do
+      it 'returns the path for the model, prefixed by parent path' do
+        child = Sync::Resource.new(@user, @project)
+        assert_equal "/projects/1/users/1", child.polymorphic_path.to_s
+      end
+    end
+
+    describe 'a resource with mixed scopes' do
+      it 'returns the path for the model, prefixed by all scopes' do
+        child = Sync::Resource.new(@user, [:en, :admin, @project])
+        assert_equal "/en/admin/projects/1/users/1", child.polymorphic_path.to_s
+      end
     end
   end
 
   describe '#polymorphic_new_path' do
-    it 'returns the path for the model' do
-      assert_equal "/users/new", Sync::Resource.new(@user).polymorphic_new_path.to_s
+    describe 'a resource without a scope' do
+      it 'returns the path for the model' do
+        assert_equal "/users/new", Sync::Resource.new(@user).polymorphic_new_path.to_s
+      end
     end
 
-    it 'returns the path for the model, prefixed by parent path' do
-      child = Sync::Resource.new(@user)
-      child.parent = Sync::Resource.new(@project)
-      assert_equal "/projects/1/users/new", child.polymorphic_new_path.to_s
+    describe 'a resource with a simple scope' do
+      it 'returns the path for the model, prefixed by the scope' do
+        resource = Sync::Resource.new(@user, :en)
+        assert_equal "/en/users/new", resource.polymorphic_new_path.to_s
+      end
     end
 
-    it 'returns the path for the model, prefixed by parent path and channel' do
-      child = Sync::Resource.new(@user)
-      child.parent = Sync::Resource.new(@project, :admin)
-      assert_equal "/admin/projects/1/users/new", child.polymorphic_new_path.to_s
+    describe 'a resource with a parent model as scope' do
+      it 'returns the path for the model, prefixed by parent path' do
+        child = Sync::Resource.new(@user, @project)
+        assert_equal "/projects/1/users/new", child.polymorphic_new_path.to_s
+      end
+    end
+
+    describe 'a resource with mixed scopes' do
+      it 'returns the path for the model, prefixed by all scopes' do
+        child = Sync::Resource.new(@user, [:en, :admin, @project])
+        assert_equal "/en/admin/projects/1/users/new", child.polymorphic_new_path.to_s
+      end
     end
   end
 end


### PR DESCRIPTION
Here is my first stab at a solution to my issue with scoping from #64.

I banged my head on this for quite a while. In theory, the channel mechanism you added a while ago would have completely sufficed to solve my problem. But there was no way to utilize it from a call to `sync_new`.

After careful consideration, I decided to first be clear about what I want to accomplish. I came up with the following goals:
- Make as few changes to the code as possible
- Stay compatible to the existing API
- Enable something like `sync_new @post, locale: :en` to solve my problem from #64
- Also, I found #51 which has similar requirements. It would be nice to solve this as well.

I think my solution fits the bill. But please review this carefully. This is the biggest change I have made so far to the code base and I am not sure if I considered all the ramifications.
