### PR TITLE
Fixed 'Missing Partial' problem in rails3 #44

### DIFF
--- a/app/controllers/sync/refetches_controller.rb
+++ b/app/controllers/sync/refetches_controller.rb
@@ -1,5 +1,5 @@
 class Sync::RefetchesController < ApplicationController
-  
+
   respond_to :json
 
   before_filter :require_valid_request
@@ -8,17 +8,25 @@ class Sync::RefetchesController < ApplicationController
 
   def show
     render json: {
-      html: @partial.render_to_string
+      html: with_format(:html){ @partial.render_to_string }
     }
   end
- 
+
 
   private
+
+  def with_format(format, &block)
+      old_formats = formats
+      self.formats = [format]
+      block_value = block.call
+      self.formats = old_formats
+      return block_value
+  end
 
   def require_valid_request
     render_bad_request unless request_valid?
   end
-  
+
   def request_valid?
     [
       params[:resource_name], 


### PR DESCRIPTION
Fixes the rendering problem listed in issue https://github.com/chrismccord/sync/issues/44#issuecomment-18639676

```
ActionView::MissingTemplate - Missing partial sync/memo_replies/refetch/memo_reply with {:locale=>[:en], :formats=>[:json], :handlers=>[:erb, :builder, :arb, :slim, :coffee]}.
```

**Cause:**
because an issue in rails 3 https://github.com/rails/rails/issues/4841
The partial always falls back to the response format (which is `json` in sync requests)

**Solution:**
Solved according to -[this StackOverflow question](http://stackoverflow.com/questions/339130/how-do-i-render-a-partial-of-a-different-format-in-rails)\-  this way:

``` ruby
def show
   render json: {
    html: with_format(:html){ @partial.render_to_string }
   }
end
```
