### PR TITLE
Allow for graceful failure if the server is not running

### DIFF
--- a/app/assets/javascripts/sync.coffee.erb
+++ b/app/assets/javascripts/sync.coffee.erb
@@ -9,9 +9,9 @@ $ = jQuery
   CLIENT_ADAPTER: "<%= Sync.adapter %>"
 
   init: ->
+    return unless Sync[@CLIENT_ADAPTER]
     @adapter = new Sync[@CLIENT_ADAPTER]
     $ =>
-      return unless window["<%= Sync.adapter %>"]?
       return if @isReady()
       @ready = true
       @connect()


### PR DESCRIPTION
Hey @chrismccord --

Wondering if you think this change would be useful? In a couple of my projects that use sync, I don't need to run Faye during development, and with this change, it no longer chokes when the server is not running.

Thanks for all your work on this great library!
