### PR TITLE
Cancel subscription channel when partial is destroyed

### DIFF
--- a/app/assets/javascripts/sync.coffee.erb
+++ b/app/assets/javascripts/sync.coffee.erb
@@ -83,14 +83,23 @@ class Sync.Faye
   isConnected: -> @client?.getState() is "CONNECTED"
 
   subscribe: (channel, callback) -> 
-    @subscriptions.push(@client.subscribe channel, callback)
-
+    subscription = new Sync.Faye.Subscription(@client, channel, callback)
+    @subscriptions.push(subscription)
+    subscription
 
   unsubscribeAll: ->
     subscription.cancel() for subscription in @subscriptions
     @subscriptions = []
 
 
+class Sync.Faye.Subscription
+  constructor: (@client, channel, callback) ->
+    @fayeSub = @client.subscribe channel, callback
+    
+  cancel: ->
+    @fayeSub.cancel()
+    
+    
 class Sync.Pusher
 
   subscriptions: []
@@ -102,15 +111,26 @@ class Sync.Pusher
   isConnected: -> @client?.connection.state is "connected"
 
   subscribe: (channel, callback) -> 
-    @subscriptions.push channel
-    channel = @client.subscribe(channel)
-    channel.bind 'sync', callback
-
+    subscription = new Sync.Pusher.Subscription(@client, channel, callback)
+    @channels.push(channel)
+    @subscriptions.push(subscription)
+    subscription
 
   unsubscribeAll: ->
-    for subscription in @subscriptions
-      @client.unsubscribe(subscription) if @client.channel(subscription)?
+    subscription.cancel() for subscription in @subscriptions
     @subscriptions = []
+
+
+    
+class Sync.Pusher.Subscription
+  constructor: (@client, channel, callback) ->
+    @pusherSub = channel
+    
+    channel = @client.subscribe(channel)
+    channel.bind 'sync', callback
+    
+  cancel: ->
+    @client.unsubscribe(@pusherSub) if @client.channel(@pusherSub)?
 
 
 class Sync.View
@@ -173,6 +193,9 @@ class Sync.Partial
     selectorEnd: null
     refetch: false
 
+    subscriptionUpdate: null
+    subscriptionDestroy: null
+
   # attributes
   #
   #   name - The String name of the partial without leading underscore
@@ -196,13 +219,13 @@ class Sync.Partial
 
 
   subscribe: ->
-    @adapter.subscribe @channelUpdate, (data) =>
+    @subscriptionUpdate = @adapter.subscribe @channelUpdate, (data) =>
       if @refetch
         @refetchFromServer (html) => @update(html)
       else
         @update(data.html)
 
-    @adapter.subscribe @channelDestroy, => @remove()
+    @subscriptionDestroy = @adapter.subscribe @channelDestroy, => @remove()
 
   
   update: (html) -> @view.beforeUpdate(html, {})
@@ -220,6 +243,8 @@ class Sync.Partial
 
 
   destroy: ->
+    @subscriptionUpdate.cancel()
+    @subscriptionDestroy.cancel()
     @$start.remove()
     @$end.remove()
     @$el?.remove()


### PR DESCRIPTION
Hi Chris!

I came across a JS-issue when trying to remove a partial from the page, which has been removed and readded before. It sounds confusing, I know. :smile: 

Well, it's a bit of an edge case. Here's what happens:
1. Add partial to the page
2. Remove it from the page
3. Add it again
4. Trying to remove it again creates a JS-Error

The error in step 4 results from the destroy-subscription still hanging around from step 1. The destroy message coming in on step 4 will then find the old subscription and try to remove the old DOM element, which of course has already been removed in step 2. 

To solve this, the subscribe method on the `Sync.Faye` and `Sync.Pusher` Class now returns a subscription object, either `Sync.Faye.Subscription` or `Sync.Pusher.Subscription`, which is then stored in the partial and can later be used to automatically unsubscribe from the channel by calling `cancel()` on it when the partial is destroyed.

Why does one need this? 

I'm currently working on an addition to scopes. It will allow you to explicitly define named syncing scopes on the model with the help of ActiveRecord Relations. In contrast to the normal procedure of adding/removing partials only when records are created/destroyed, this approach also needs to add and remove them when certain attributes on the record have changed. This may lead to the need of adding/removing records multiple times, depending on the use case of course.

I tested this patch with a Faye setup and it works fine. Maybe someone can confirm it works with Pusher as well.

Let me know, what you think. And again, thanks for the awesome gem! 
