### PR TITLE
Prevent erroring out when Faye is unavailable

### DIFF
--- a/app/assets/javascripts/sync.coffee.erb
+++ b/app/assets/javascripts/sync.coffee.erb
@@ -77,12 +77,13 @@ class Sync.Faye
   subscriptions: []
 
   connect: ->
-    @client = new window.Faye.Client(Sync.FAYE_HOST)
+    @client = new window.Faye?.Client(Sync.FAYE_HOST)
 
 
   isConnected: -> @client?.getState() is "CONNECTED"
 
   subscribe: (channel, callback) -> 
+    return unless @client?
     subscription = new Sync.Faye.Subscription(@client, channel, callback)
     @subscriptions.push(subscription)
     subscription


### PR DESCRIPTION
Right now, if your Faye server is down javascript execution is halted for the rest of the site when Sync can't establish a client
