### PR TITLE
OpenSSL::Digest::Digest deprecated, fixes deprecation warnings

### DIFF
--- a/lib/sync/channel.rb
+++ b/lib/sync/channel.rb
@@ -10,7 +10,7 @@ module Sync
 
     def signature
       OpenSSL::HMAC.hexdigest(
-        OpenSSL::Digest::Digest.new('sha1'),
+        OpenSSL::Digest.new('sha1'),
         Sync.auth_token,
         self.name
       )


### PR DESCRIPTION
OpenSSL::Digest::Digest has been deprecated for awhile. In Ruby 2.1.0, this causes a lot of warnings.
