### PR TITLE
Send message in request body

### DIFF
--- a/lib/sync/clients/faye.rb
+++ b/lib/sync/clients/faye.rb
@@ -46,7 +46,7 @@ module Sync
 
         def self.batch_publish_asynchronous(messages)
           Sync.reactor.perform do
-            EM::HttpRequest.new(Sync.server).post(query: {
+            EM::HttpRequest.new(Sync.server).post(body: {
               message: batch_messages_query_hash(messages).to_json
             })
           end
@@ -93,7 +93,7 @@ module Sync
 
         def publish_asynchronous
           Sync.reactor.perform do
-            EM::HttpRequest.new(Sync.server).post(query: {
+            EM::HttpRequest.new(Sync.server).post(body: {
               message: self.to_json
             })
           end


### PR DESCRIPTION
Fixes Issue #54 with thin complaining about too long query string when trying to post 'large' messages to faye server. Uses the request body for the payload rather than the query string.

We should be quite save with this. Just tried it for fun: it also works with 16MB+ of payload! :smile: 
