### PR TITLE
Support PusherFake

### DIFF
--- a/app/assets/javascripts/sync.coffee.erb
+++ b/app/assets/javascripts/sync.coffee.erb
@@ -128,7 +128,7 @@ class Sync.Pusher extends Sync.Adapter
     !!window.Pusher
 
   connect: ->
-    @client = <%= defined?(PusherFake) ? "new window.Pusher('#{PusherFake.configuration.app_id}', {'wsHost': '#{PusherFake.configuration.web_options[:host]}', 'wsPort': #{PusherFake.configuration.web_options[:port]}, 'enabledTransports': ['ws']})" : "new window.Pusher(Sync.PUSHER_API_KEY)" %>
+    @client = <%= defined?(PusherFake) ? "new window.Pusher(#{[PusherFake.configuration.key, PusherFake.configuration.to_options].map(&:to_json).join(",")})" : "new window.Pusher(Sync.PUSHER_API_KEY)" %>
 
   isConnected: -> @client?.connection.state is "connected"
 

--- a/app/assets/javascripts/sync.coffee.erb
+++ b/app/assets/javascripts/sync.coffee.erb
@@ -128,7 +128,7 @@ class Sync.Pusher extends Sync.Adapter
     !!window.Pusher
 
   connect: ->
-    @client = new window.Pusher(Sync.PUSHER_API_KEY)
+    @client = <%= defined?(PusherFake) ? "new window.Pusher('#{PusherFake.configuration.app_id}', {'wsHost': '#{PusherFake.configuration.web_options[:host]}', 'wsPort': #{PusherFake.configuration.web_options[:port]}, 'enabledTransports': ['ws']})" : "new window.Pusher(Sync.PUSHER_API_KEY)" %>
 
   isConnected: -> @client?.connection.state is "connected"
 


### PR DESCRIPTION
While some may use Faye for development and Pusher for production, another alternative is to use [PusherFake](https://github.com/tristandunn/pusher-fake/) in dev/test and Pusher in prod.  The [documentation](https://github.com/tristandunn/pusher-fake/blob/master/README.markdown#1-use-the-pusherfake-js-for-the-pusher-js-instance) states that you should use `var instance = <%= PusherFake.javascript %>;` to instantiate it, but that appears to conflict with the local namespaced `Pusher` due to how it's [constructed](https://github.com/tristandunn/pusher-fake/blob/master/lib/pusher-fake.rb#L44).  Instead, I went with inlining the config so `new window.Pusher(` could be used.

Going with `defined?(PusherFake) ?` seemed like the easiest way to easily setup the alternate config, as that is how they recommend doing it in the README.