### PR TITLE
Fixes travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ gemfile:
   - gemfiles/Gemfile.rails-3.x
   - gemfiles/Gemfile.rails-4.x
 
+before_install:
+  - gem update bundler
+
 # Set up and start Faye Server before tests are run
 before_script:
   - cp test/travis/sync.yml config/sync.yml

--- a/gemfiles/Gemfile.rails-4.x
+++ b/gemfiles/Gemfile.rails-4.x
@@ -2,3 +2,5 @@ source "https://rubygems.org"
 gemspec path: '..'
 
 gem "rails", '~>4'
+gem 'mime-types', '~> 2.9'
+gem 'json', '~>1.8.3'


### PR DESCRIPTION
Fixes travis build:
- Update bundler before install
- Set gem versions (json and mime-types) to broken build ruby 1.9.3 and rails 4 

Travis build passing: https://travis-ci.org/Godoy/render_sync/builds/144786608
