### PR TITLE
Update to support Rails 5

### DIFF
--- a/app/controllers/sync/refetches_controller.rb
+++ b/app/controllers/sync/refetches_controller.rb
@@ -1,8 +1,8 @@
 class RenderSync::RefetchesController < ApplicationController
 
-  before_filter :require_valid_request
-  before_filter :find_resource
-  before_filter :find_authorized_partial
+  before_action :require_valid_request
+  before_action :find_resource
+  before_action :find_authorized_partial
 
   def show
     render json: {

--- a/lib/render_sync/controller_helpers.rb
+++ b/lib/render_sync/controller_helpers.rb
@@ -10,7 +10,7 @@ module RenderSync
 
     module ClassMethods
       def enable_sync(options = {})
-        around_filter :enable_sync, options
+        around_action :enable_sync, options
       end
     end
 


### PR DESCRIPTION
fix issue #233
Change from around_filter and before_filter to around_actiond and before_action to support Rails 5.

the erros on CI appear to be some deprecated things

obs.: until the maintainer accepts the PR people can use my branch on Rails 5: (https://github.com/cassianoblonski/render_sync/)